### PR TITLE
Add preset standort configuration for ASEA userscript

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     {
       "id": "tool-ssw-letzter08",
       "name": "ASEA inkl. letzter Lagerscan (mit Standort-Setting)",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "url": "https://raw.githubusercontent.com/toni2123a/company-userscripts/main/tools/tool-SSW-letzter08.user.js",
       "match": [
         "https://toni2123a.github.io/company-userscripts/*",
@@ -15,7 +15,7 @@
         "GM_addStyle",
         "GM_xmlhttpRequest"
       ],
-      "description": "Zeigt den letzten Eintrag aus den Scanserver-Daten. Standortnummer wird auf der Katalog-Seite gespeichert (GM-Storage + localStorage) und auf DPD-Seiten genutzt."
+      "description": "Zeigt den letzten Eintrag aus den Scanserver-Daten. Standortnummer kann im Script vorbelegt oder auf der Katalog-Seite gespeichert werden (GM-Storage + localStorage) und wird auf DPD-Seiten genutzt."
     },
     {
       "id": "tool-openpricer",


### PR DESCRIPTION
## Summary
- allow defining an optional preset standort directly in the ASEA userscript
- disable the catalog UI when a preset is configured and keep storage in sync
- regenerate the manifest to publish the updated version metadata

## Testing
- node build-manifest.js

------
https://chatgpt.com/codex/tasks/task_e_68dd0aff12c4832ebff4dd40560677de